### PR TITLE
Add CurrentlyLive status by default for API v 2 requests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -3,17 +3,21 @@ import unittest
 
 from httpretty import HTTPretty, httprettified
 
-from builtwith import (BuiltWithDomainInfo, BuiltWith, UnsupportedApiVersion,
-                       ENDPOINTS_BY_API_VERSION, VERSION_EXCEPTION_TEMPLATE)
+import builtwith
 
 
 API_VERSION_ONE = 1
 API_VERSION_TWO = 2
 UNSUPPORTED_API_VERSION = 3
 
-TEST_FULL_SCAN_DATE = datetime.date(2013, 5, 30)
-TEST_DATETIME = datetime.datetime(2012, 9, 6, 23, 0)
-TEST_DATETIME_STRING = u'/Date(1346972400000)/'
+TEST_EPOCH_TIME = 1346972400
+TEST_DATETIME = datetime.datetime.utcfromtimestamp(TEST_EPOCH_TIME) # 2012-9-6
+TEST_DATETIME_STRING = u'/Date(%s)/' % (TEST_EPOCH_TIME * 1000)
+
+# Dates are named relative to the TEST_EPOCH_TIME
+TEST_FULL_SCAN_DATE_BEFORE = datetime.date(2012, 5, 30)
+TEST_FULL_SCAN_DATE_AFTER = datetime.date(2012, 10, 6)
+TEST_TOPSITE_DATE = datetime.date(2012, 6, 19)
 
 TEST_RESPONSE_JSON = {
   u'Paths': [{u'Url': u'',
@@ -56,11 +60,11 @@ TEST_RESPONSE_JSON = {
 class BuiltWithTests(unittest.TestCase):
 
     @httprettified
-    def test_lookup(self):
-        bw = BuiltWith('key')
-        HTTPretty.register_uri(HTTPretty.GET, ENDPOINTS_BY_API_VERSION[API_VERSION_ONE], body='true')
+    def test_lookup_version_one(self):
+        bw = builtwith.BuiltWith('key')
+        HTTPretty.register_uri(HTTPretty.GET, builtwith.ENDPOINTS_BY_API_VERSION[API_VERSION_ONE], body='true')
 
-        result = bw.lookup('example.com', last_full_query=True)
+        result = bw.lookup('example.com')
 
         qs = HTTPretty.last_request.querystring
         self.assertEqual(qs.get('KEY'), ['key'])
@@ -69,23 +73,24 @@ class BuiltWithTests(unittest.TestCase):
 
 
     @httprettified
-    def test_lookup_alternate_version(self):
-        bw = BuiltWith('key', api_version=API_VERSION_TWO)
+    def test_lookup_version_two(self):
+        bw = builtwith.BuiltWith('key', api_version=API_VERSION_TWO)
 
 
-        HTTPretty.register_uri(HTTPretty.GET, ENDPOINTS_BY_API_VERSION[API_VERSION_TWO],
+        HTTPretty.register_uri(HTTPretty.GET, builtwith.ENDPOINTS_BY_API_VERSION[API_VERSION_TWO],
                                body='{"Paths": []}')
 
-        HTTPretty.register_uri(HTTPretty.GET, ENDPOINTS_BY_API_VERSION[API_VERSION_TWO],
-                               body='{"TOPSITE": "2013-06-19", "FULL": "%s"}' % TEST_FULL_SCAN_DATE)
+        HTTPretty.register_uri(HTTPretty.GET, builtwith.ENDPOINTS_BY_API_VERSION[API_VERSION_TWO],
+                               body='{"TOPSITE": "%s", "FULL": "%s"}' % (TEST_TOPSITE_DATE,
+                                                                         TEST_FULL_SCAN_DATE_BEFORE))
 
-        result = bw.lookup('example.com', last_full_query=True)
+        result = bw.lookup('example.com')
 
         qs = HTTPretty.last_request.querystring
         self.assertEqual(qs.get('KEY'), ['key'])
         self.assertEqual(qs.get('LOOKUP'), ['example.com'])
         self.assertTrue(result)
-        self.assertIsInstance(result, BuiltWithDomainInfo)
+        self.assertIsInstance(result, builtwith.BuiltWithDomainInfo)
         self.assertDictEqual({'Paths': []}, result.api_response_json)
 
 
@@ -94,17 +99,16 @@ class BuiltWithTests(unittest.TestCase):
         exception_raised = False
 
         try:
-            BuiltWith('key', api_version=UNSUPPORTED_API_VERSION)
-        except UnsupportedApiVersion as e:
+          builtwith.BuiltWith('key', api_version=UNSUPPORTED_API_VERSION)
+        except builtwith.UnsupportedApiVersion as e:
             exception_raised = True
-            self.assertEqual(VERSION_EXCEPTION_TEMPLATE % UNSUPPORTED_API_VERSION, str(e))
+            self.assertEqual(builtwith.VERSION_EXCEPTION_TEMPLATE % UNSUPPORTED_API_VERSION, str(e))
 
         self.assertTrue(exception_raised)
 
 
-    @httprettified
     def test_domain_info_object(self):
-        domain_info = BuiltWithDomainInfo(TEST_RESPONSE_JSON, last_full_builtwith_scan_date=TEST_FULL_SCAN_DATE)
+        domain_info = builtwith.BuiltWithDomainInfo(TEST_RESPONSE_JSON)
 
         self.assertListEqual(sorted([(u'example.com', u'', u''), (u'example.com', u'test', u'')]),
                              sorted(domain_info.available_urls()))
@@ -117,9 +121,51 @@ class BuiltWithTests(unittest.TestCase):
 
         self.assertEqual(js_info['Name'], 'Javascript')
         self.assertEqual(js_info['LastDetected'], TEST_DATETIME)
-        self.assertFalse(js_info['CurrentlyLive'])
+        self.assertEqual(None, js_info.get('CurrentlyLive'))
 
         html5_info = url_technologies.get_technology_info('HTML5 DocType')
         self.assertEqual(html5_info['Name'], 'HTML5 DocType')
         self.assertEqual(html5_info['LastDetected'], TEST_DATETIME)
-        self.assertFalse(html5_info['CurrentlyLive'])
+        self.assertEqual(None, html5_info.get('CurrentlyLive'))
+
+
+    def test_currently_live_fetching_with_scan_before(self):
+        domain_info = builtwith.BuiltWithDomainInfo(TEST_RESPONSE_JSON,
+                                                    last_full_builtwith_scan_date=TEST_FULL_SCAN_DATE_BEFORE)
+
+        url_technologies = domain_info.get_technologies_by_url(domain='example.com', subdomain='', path='')
+
+        js_info = url_technologies.get_technology_info('Javascript')
+
+        self.assertEqual(js_info['Name'], 'Javascript')
+        self.assertEqual(js_info['LastDetected'], TEST_DATETIME)
+        self.assertTrue(js_info['CurrentlyLive'])
+
+        html5_info = url_technologies.get_technology_info('HTML5 DocType')
+        self.assertEqual(html5_info['Name'], 'HTML5 DocType')
+        self.assertEqual(html5_info['LastDetected'], TEST_DATETIME)
+        self.assertTrue(html5_info['CurrentlyLive'])
+
+
+    def test_currently_live_fetching_with_scan_after(self):
+      domain_info = builtwith.BuiltWithDomainInfo(TEST_RESPONSE_JSON,
+                                                  last_full_builtwith_scan_date=TEST_FULL_SCAN_DATE_AFTER)
+
+      url_technologies = domain_info.get_technologies_by_url(domain='example.com', subdomain='', path='')
+
+      js_info = url_technologies.get_technology_info('Javascript')
+
+      self.assertEqual(js_info['Name'], 'Javascript')
+      self.assertEqual(js_info['LastDetected'], TEST_DATETIME)
+      self.assertFalse(js_info['CurrentlyLive'])
+
+      html5_info = url_technologies.get_technology_info('HTML5 DocType')
+      self.assertEqual(html5_info['Name'], 'HTML5 DocType')
+      self.assertEqual(html5_info['LastDetected'], TEST_DATETIME)
+      self.assertFalse(html5_info['CurrentlyLive'])
+
+
+    def test__convert_string_to_utc_datetime(self):
+        converted_utc_datetime = builtwith._convert_string_to_utc_datetime(TEST_DATETIME_STRING)
+
+        self.assertEqual(converted_utc_datetime, TEST_DATETIME)


### PR DESCRIPTION
Added in unit tests as well. Changed up the way the UrlTechnologiesSet objects are initialized, so as to avoid modifying the variables used for construction.
